### PR TITLE
Update broken neural_style_transfer links

### DIFF
--- a/Guide.md
+++ b/Guide.md
@@ -16,7 +16,7 @@ There are various parameters in both Network.py and INetwork.py scripts that can
 # Acknowledgements
 
 Uses the VGG-16 model as described in the Keras example below :
-https://github.com/fchollet/keras/blob/master/examples/neural_style_transfer.py
+https://github.com/keras-team/keras-io/blob/master/examples/generative/neural_style_transfer.py
 
 Uses weights from Keras Deep Learning Models : https://github.com/fchollet/deep-learning-models
 

--- a/INetwork.py
+++ b/INetwork.py
@@ -22,7 +22,7 @@ from keras.utils.layer_utils import convert_all_kernels_in_model
 Neural Style Transfer with Keras 2.0.5
 
 Based on:
-https://github.com/fchollet/keras/blob/master/examples/neural_style_transfer.py
+https://github.com/keras-team/keras-io/blob/master/examples/generative/neural_style_transfer.py
 
 Contains few improvements suggested in the paper Improving the Neural Algorithm of Artistic Style
 (http://arxiv.org/abs/1605.04603).

--- a/MRFNetwork.py
+++ b/MRFNetwork.py
@@ -18,7 +18,7 @@ from keras import backend as K
 Neural Style Transfer with Keras 1.0.6
 
 Uses the VGG-16 model as described in the Keras example below :
-https://github.com/fchollet/keras/blob/master/examples/neural_style_transfer.py
+https://github.com/keras-team/keras-io/blob/master/examples/generative/neural_style_transfer.py
 
 Note:
 

--- a/Network.py
+++ b/Network.py
@@ -22,7 +22,7 @@ from keras.utils.layer_utils import convert_all_kernels_in_model
 Neural Style Transfer with Keras 2.0.5
 
 Based on:
-https://github.com/fchollet/keras/blob/master/examples/neural_style_transfer.py
+https://github.com/keras-team/keras-io/blob/master/examples/generative/neural_style_transfer.py
 
 -----------------------------------------------------------------------------------------------------------------------
 """

--- a/inetwork_tf.py
+++ b/inetwork_tf.py
@@ -25,7 +25,7 @@ from tf_bfgs import LBFGSOptimizer
 Neural Style Transfer with Keras 2.0.5
 
 Based on:
-https://github.com/fchollet/keras/blob/master/examples/neural_style_transfer.py
+https://github.com/keras-team/keras-io/blob/master/examples/generative/neural_style_transfer.py
 
 Contains few improvements suggested in the paper Improving the Neural Algorithm of Artistic Style
 (http://arxiv.org/abs/1605.04603).

--- a/inetwork_tf_lbfgs.py
+++ b/inetwork_tf_lbfgs.py
@@ -25,7 +25,7 @@ from tf_bfgs import LBFGSOptimizer
 Neural Style Transfer with Keras 2.0.5
 
 Based on:
-https://github.com/fchollet/keras/blob/master/examples/neural_style_transfer.py
+https://github.com/keras-team/keras-io/blob/master/examples/generative/neural_style_transfer.py
 
 Contains few improvements suggested in the paper Improving the Neural Algorithm of Artistic Style
 (http://arxiv.org/abs/1605.04603).

--- a/script_helper/Script/INetwork.py
+++ b/script_helper/Script/INetwork.py
@@ -22,7 +22,7 @@ from keras.utils.layer_utils import convert_all_kernels_in_model
 Neural Style Transfer with Keras 2.0.5
 
 Based on:
-https://github.com/fchollet/keras/blob/master/examples/neural_style_transfer.py
+https://github.com/keras-team/keras-io/blob/master/examples/generative/neural_style_transfer.py
 
 Contains few improvements suggested in the paper Improving the Neural Algorithm of Artistic Style
 (http://arxiv.org/abs/1605.04603).

--- a/script_helper/Script/Network.py
+++ b/script_helper/Script/Network.py
@@ -22,7 +22,7 @@ from keras.utils.layer_utils import convert_all_kernels_in_model
 Neural Style Transfer with Keras 2.0.5
 
 Based on:
-https://github.com/fchollet/keras/blob/master/examples/neural_style_transfer.py
+https://github.com/keras-team/keras-io/blob/master/examples/generative/neural_style_transfer.py
 
 -----------------------------------------------------------------------------------------------------------------------
 """


### PR DESCRIPTION
Was going through your implementation and realized that the neural_style_transfer and neural_doodle links were broken (404). 

Couldn't find fchollet's version of neural_doodle, but I have updated the neural_style_transfer links to the keras-io examples. (examples have been moved from keras to keras-io)